### PR TITLE
Defined conditions in the while loops in a more strict manner to be compatible with PHP 8.5

### DIFF
--- a/errors.php
+++ b/errors.php
@@ -119,12 +119,18 @@ class SimpleErrorQueue
      */
     public function tally()
     {
-        while (list($severity, $message, $file, $line) = $this->extract()) {
-            $severity = $this->getSeverityAsString($severity);
-            $this->test->error($severity, $message, $file, $line);
+        while ($error = $this->extract()) {
+            if (is_array($error)) {
+                list($severity, $message, $file, $line) = $error;
+                $severity = $this->getSeverityAsString($severity);
+                $this->test->error($severity, $message, $file, $line);
+            }
         }
-        while (list($expected, $message) = $this->extractExpectation()) {
-            $this->test->assert($expected, false, '%s -> Expected error not caught');
+        while ($expectation = $this->extractExpectation()) {
+            if (is_array($expectation)) {
+                list($expected, $message) = $expectation;
+                $this->test->assert($expected, false, '%s -> Expected error not caught');
+            }
         }
     }
 


### PR DESCRIPTION
The following warnings were repeatedly displayed when I ran tests/index.php in the htmlpurifier repository using PHP 8.5.
To resolve this issue, I created a pull request to backport from https://github.com/simpletest/simpletest/commit/ecd8172637bb3b040656033694147ec6c2e90bac.
```
% /opt/homebrew/opt/php@8.5/bin/php tests/index.php
(snip)
Warning: Cannot use bool as array in /tmp/htmlpurifier/vendor/simpletest/simpletest/errors.php on line 122

Warning: Cannot use bool as array in /tmp/htmlpurifier/vendor/simpletest/simpletest/errors.php on line 126
```
[Related]
https://github.com/ezyang/htmlpurifier/actions/runs/24589106932/job/71905812009#step:6:23


There are no issues with PHP 8.4 or earlier.
```
% /opt/homebrew/opt/php@8.4/bin/php tests/index.php
All HTML Purifier tests on PHP 8.4.17
OK
Test cases run: 226/226, Passes: 2856, Failures: 0, Exceptions: 0
```

Thank you.