### PR TITLE
Fix deprecated non-canonical casts for PHP 8.5 compatibility

### DIFF
--- a/autorun.php
+++ b/autorun.php
@@ -67,7 +67,7 @@ function tests_have_run()
 {
     $context = SimpleTest::getContext();
     if ($context) {
-        return (boolean) $context->getTest();
+        return (bool) $context->getTest();
     }
 
     return false;

--- a/browser.php
+++ b/browser.php
@@ -1009,7 +1009,7 @@ class SimpleBrowser
      */
     public function isSubmit($label)
     {
-        return (boolean) $this->page->getFormBySubmit(new SimpleByLabel($label));
+        return (bool) $this->page->getFormBySubmit(new SimpleByLabel($label));
     }
 
     /**
@@ -1095,7 +1095,7 @@ class SimpleBrowser
      */
     public function isImage($label)
     {
-        return (boolean) $this->page->getFormByImage(new SimpleByLabel($label));
+        return (bool) $this->page->getFormByImage(new SimpleByLabel($label));
     }
 
     /**

--- a/docs/source/en/mock_objects_tutorial.xml
+++ b/docs/source/en/mock_objects_tutorial.xml
@@ -68,7 +68,7 @@ class TestOfLogging extends TimeTestCase {</strong>
                 preg_match('/(\d+)/', $this->getFileLine('../temp/test.log', 0), $matches),
                 'Found timestamp');
         $clock = new clock();
-        $this->assertSameTime((integer)$matches[1], $clock->now(), 'Correct time');
+        $this->assertSameTime((int)$matches[1], $clock->now(), 'Correct time');
     }</strong>
 }
 ?>

--- a/docs/source/fr/mock_objects_tutorial.xml
+++ b/docs/source/fr/mock_objects_tutorial.xml
@@ -71,7 +71,7 @@ class TestOfLogging extends TimeTestCase {</strong>
                 preg_match('/(\d+)/', $this->getFileLine('../temp/test.log', 0), $matches),
                 'Found timestamp');
         $clock = new clock();
-        $this->assertSameTime((integer)$matches[1], $clock->now(), 'Correct time');
+        $this->assertSameTime((int)$matches[1], $clock->now(), 'Correct time');
     }</strong>
 }
 ?>

--- a/docs/source/it/mock_objects_tutorial.xml
+++ b/docs/source/it/mock_objects_tutorial.xml
@@ -68,7 +68,7 @@ class TestOfLogging extends TimeTestCase {</strong>
                 preg_match('/(\d+)/', $this->getFileLine('../temp/test.log', 0), $matches),
                 'Found timestamp');
         $clock = new clock();
-        $this->assertSameTime((integer)$matches[1], $clock->now(), 'Correct time');
+        $this->assertSameTime((int)$matches[1], $clock->now(), 'Correct time');
     }</strong>
 }
 ?>

--- a/dumper.php
+++ b/dumper.php
@@ -420,7 +420,7 @@ class SimpleDumper
         $position = 0;
         $step     = strlen($first);
         while ($step > 1) {
-            $step = (integer) (($step + 1) / 2);
+            $step = (int) (($step + 1) / 2);
             if (strncmp($first, $second, $position + $step) == 0) {
                 $position += $step;
             }

--- a/encoding.php
+++ b/encoding.php
@@ -475,7 +475,7 @@ class SimpleEntityEncoding extends SimpleEncoding
      */
     public function writeHeadersTo(&$socket)
     {
-        $socket->write('Content-Length: ' . (integer) strlen($this->encode()) . "\r\n");
+        $socket->write('Content-Length: ' . (int) strlen($this->encode()) . "\r\n");
         $socket->write('Content-Type: ' .  $this->getContentType() . "\r\n");
     }
 
@@ -620,7 +620,7 @@ class SimpleMultipartEncoding extends SimplePostEncoding
      */
     public function writeHeadersTo(&$socket)
     {
-        $socket->write('Content-Length: ' . (integer) strlen($this->encode()) . "\r\n");
+        $socket->write('Content-Length: ' . (int) strlen($this->encode()) . "\r\n");
         $socket->write('Content-Type: multipart/form-data; boundary=' . $this->boundary . "\r\n");
     }
 

--- a/expectation.php
+++ b/expectation.php
@@ -175,7 +175,7 @@ class TrueExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return (boolean) $compare;
+        return (bool) $compare;
     }
 
     /**
@@ -207,7 +207,7 @@ class FalseExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return ! (boolean) $compare;
+        return ! (bool) $compare;
     }
 
     /**
@@ -675,7 +675,7 @@ class PatternExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return (boolean) preg_match($this->getPattern(), $compare);
+        return (bool) preg_match($this->getPattern(), $compare);
     }
 
     /**
@@ -923,7 +923,7 @@ class MethodExistsExpectation extends SimpleExpectation
      */
     public function test($compare)
     {
-        return (boolean) (is_object($compare) && method_exists($compare, $this->method));
+        return (bool) (is_object($compare) && method_exists($compare, $this->method));
     }
 
     /**

--- a/http.php
+++ b/http.php
@@ -360,7 +360,7 @@ class SimpleHttpHeaders
      */
     public function getResponseCode()
     {
-        return (integer) $this->response_code;
+        return (int) $this->response_code;
     }
 
     /**
@@ -381,7 +381,7 @@ class SimpleHttpHeaders
     public function isRedirect()
     {
         return in_array($this->response_code, array(301, 302, 303, 307)) &&
-                (boolean) $this->getLocation();
+                (bool) $this->getLocation();
     }
 
     /**
@@ -392,8 +392,8 @@ class SimpleHttpHeaders
     public function isChallenge()
     {
         return ($this->response_code == 401) &&
-                (boolean) $this->authentication &&
-                (boolean) $this->realm;
+                (bool) $this->authentication &&
+                (bool) $this->realm;
     }
 
     /**

--- a/page.php
+++ b/page.php
@@ -285,7 +285,7 @@ class SimplePage
     {
         $parsed = new SimpleUrl($url);
 
-        return (boolean) ($parsed->getScheme() && $parsed->getHost());
+        return (bool) ($parsed->getScheme() && $parsed->getHost());
     }
 
     /**

--- a/tag.php
+++ b/tag.php
@@ -786,7 +786,7 @@ class SimpleTextAreaTag extends SimpleWidget
         if ($this->wrapIsEnabled()) {
             return wordwrap(
                     $text,
-                    (integer) $this->getAttribute('cols'),
+                    (int) $this->getAttribute('cols'),
                     "\r\n");
         }
 

--- a/test/user_agent_test.php
+++ b/test/user_agent_test.php
@@ -216,7 +216,7 @@ class TestOfHttpRedirects extends UnitTestCase
     public function createRedirect($content, $redirect)
     {
         $headers = new MockSimpleHttpHeaders();
-        $headers->returnsByValue('isRedirect', (boolean) $redirect);
+        $headers->returnsByValue('isRedirect', (bool) $redirect);
         $headers->returnsByValue('getLocation', $redirect);
         $response = new MockSimpleHttpResponse();
         $response->returnsByValue('getContent', $content);

--- a/url.php
+++ b/url.php
@@ -55,7 +55,7 @@ class SimpleUrl
                 $this->host = false;
             } else {
                 $this->host = $host_parts[1];
-                $this->port = (integer) $host_parts[2];
+                $this->port = (int) $host_parts[2];
             }
         }
         $this->path     = $this->chompPath($url);
@@ -76,7 +76,7 @@ class SimpleUrl
         if (preg_match('/(.*)\?(\d+),(\d+)$/', $url, $matches)) {
             $url = $matches[1];
 
-            return array((integer) $matches[2], (integer) $matches[3]);
+            return array((int) $matches[2], (int) $matches[3]);
         }
 
         return array(false, false);
@@ -348,8 +348,8 @@ class SimpleUrl
 
             return;
         }
-        $this->x = (integer) $x;
-        $this->y = (integer) $y;
+        $this->x = (int) $x;
+        $this->y = (int) $y;
     }
 
     /**

--- a/xml.php
+++ b/xml.php
@@ -459,7 +459,7 @@ class NestingGroupTag extends NestingXmlTag
     {
         $attributes = $this->getAttributes();
         if (isset($attributes['SIZE'])) {
-            return (integer) $attributes['SIZE'];
+            return (int) $attributes['SIZE'];
         }
 
         return 0;


### PR DESCRIPTION
The following deprecated messages were displayed when running tests/index.php in the htmlpurifier repository using PHP 8.5.

https://github.com/ezyang/htmlpurifier/actions/runs/24589106932/job/71905812009#step:6:10
```
Deprecated: Non-canonical cast (boolean) is deprecated, use the (bool) cast instead in /home/runner/work/htmlpurifier/htmlpurifier/vendor/simpletest/simpletest/expectation.php on line 178

Deprecated: Non-canonical cast (boolean) is deprecated, use the (bool) cast instead in /home/runner/work/htmlpurifier/htmlpurifier/vendor/simpletest/simpletest/expectation.php on line 210

Deprecated: Non-canonical cast (boolean) is deprecated, use the (bool) cast instead in /home/runner/work/htmlpurifier/htmlpurifier/vendor/simpletest/simpletest/expectation.php on line 678

Deprecated: Non-canonical cast (boolean) is deprecated, use the (bool) cast instead in /home/runner/work/htmlpurifier/htmlpurifier/vendor/simpletest/simpletest/expectation.php on line 926

Deprecated: Non-canonical cast (integer) is deprecated, use the (int) cast instead in /home/runner/work/htmlpurifier/htmlpurifier/vendor/simpletest/simpletest/dumper.php on line 423

Deprecated: Non-canonical cast (integer) is deprecated, use the (int) cast instead in /home/runner/work/htmlpurifier/htmlpurifier/vendor/simpletest/simpletest/xml.php on line 462
```

This is because non-canonical cast names (boolean) and (integer) have been deprecated in PHP 8.5. We must use (bool) and (int) instead.
ref: https://www.php.net/manual/en/migration85.deprecated.php
To resolve this issue, I created a pull request to use (bool) and (int) instead.

Thank you.